### PR TITLE
chore: extract `.prettierrc` file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,20 @@
+{
+	"proseWrap": "always",
+	"singleQuote": true,
+	"tabWidth": 4,
+	"trailingComma": "all",
+	"useTabs": true,
+	"overrides": [
+		{
+			"files": [
+				"*.md",
+				"*.yml"
+			],
+			"options": {
+				"printWidth": 120,
+				"tabWidth": 2,
+				"useTabs": false
+			}
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -36,26 +36,6 @@
 		"fmt": "prettier  --write --list-different \"{*,{src,examples}/**/*,.github/**/*}.+(ts|json|yml|md)\"",
 		"typecheck": "tsc --noEmit"
 	},
-	"prettier": {
-		"proseWrap": "always",
-		"singleQuote": true,
-		"tabWidth": 4,
-		"trailingComma": "all",
-		"useTabs": true,
-		"overrides": [
-			{
-				"files": [
-					"*.md",
-					"*.yml"
-				],
-				"options": {
-					"printWidth": 120,
-					"tabWidth": 2,
-					"useTabs": false
-				}
-			}
-		]
-	},
 	"dependencies": {
 		"diary": "^0.2.0"
 	},


### PR DESCRIPTION
People have to download this when you include it in the package.json file