### PR TITLE
fix exports to include types as required by typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 	"exports": {
 		".": {
 			"import": "./index.mjs",
-			"require": "./index.js"
+			"require": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
typescript will expect to read from the "types" in the "exports" field if that one is present.

This PR add it so typescript do not complain
